### PR TITLE
Minor spelling fix in AnalyzePESig.cpp to generate valid XML output

### DIFF
--- a/AnalyzePESig/AnalyzePESig.cpp
+++ b/AnalyzePESig/AnalyzePESig.cpp
@@ -319,7 +319,7 @@ void AnalyzePEFile(string filename, _TCHAR* pszCatalogFile, ostream& output, BOO
 			output << XMLElementSingleLine(4, _TEXT("characteristicsDecode"), DecodeCharacteristics(uiCharacteristics)) << endl;
 			output << _TEXT("    <magic>") << uiMagic << _TEXT("</magic>") << endl;
 			output << _TEXT("    <magicDecode>") << DecodeMagic(uiMagic) << _TEXT("</magicDecode>") << endl;
-			output << _TEXT("    <subsystem>") << uiSubsystem << _TEXT("</susbsystem>") << endl;
+			output << _TEXT("    <subsystem>") << uiSubsystem << _TEXT("</subsystem>") << endl;
 			output << _TEXT("    <sizeOfCode>") << std::dec << uiSizeOfCode << std::hex << _TEXT("</sizeOfCode>") << endl;
 			output << _TEXT("    <addressOfEntryPoint>") << uiAddressOfEntryPoint << _TEXT("</addressOfEntryPoint>") << endl;
 			output << XMLElementSingleLine(4, _TEXT("compiletime"), compiletime) << endl;


### PR DESCRIPTION
Current XML output produces errors like this when trying to open...

"The end tag "subsystem" does not match the start tag "subsystem". Line 20, Position 19. <subsystem>2</susbsystem>"